### PR TITLE
Fix missing headings in issue pages

### DIFF
--- a/source/_includes/issue.liquid
+++ b/source/_includes/issue.liquid
@@ -1,0 +1,9 @@
+---
+layout: layout
+---
+
+<h2>{{ title }}</h2>
+
+{{ content | safe }}
+
+

--- a/source/issues/budget.md
+++ b/source/issues/budget.md
@@ -1,12 +1,10 @@
 ---
 excerpt: We must anticipate the City’s needs and be responsible in our financial planning for the future! As a Council Member, I will work towards a fiscal policy which promotes a balanced budget and protects our residential homeowners from increasing property taxes. My budget policy includes pursuing alternative revenue generating solutions and prioritizing our City’s investments.
-layout: layout
+layout: issue
 order: 4
 section: Issues
 title: Budget
 ---
-
-## {{ page.title }}
 
 We must anticipate the City’s needs and be responsible in our financial planning for the future! As a Council Member, I will work towards a fiscal policy which promotes a balanced budget and protects our residential homeowners from increasing property taxes. My budget policy includes pursuing alternative revenue generating solutions and prioritizing our City’s investments.
 

--- a/source/issues/business-development.md
+++ b/source/issues/business-development.md
@@ -1,12 +1,10 @@
 ---
 excerpt: As a Council Member my number one priority will be the City’s relationship with the Community. We are elected to represent your voices at City Hall. I promise to restore this relationship with our community. In addition to my commitment to people before profit I will focus on the relationship between our police and the community, work to expand the responsibilities of the Volunteer Coordinator, and create supplemental Community Advisory Boards to work hand in hand with our City Committees.
-layout: layout
+layout: issue
 order: 3
 section: Issues
 title: Community-City Relationship
 ---
-
-## {{ page.title }}
 
 As a Council Member my number one priority will be the City’s relationship with the Community. We are elected to represent your voices at City Hall. I promise to restore this relationship with our community. In addition to my commitment to people before profit I will focus on the relationship between our police and the community, work to expand the responsibilities of the Volunteer Coordinator, and create supplemental Community Advisory Boards to work hand in hand with our City Committees.
 

--- a/source/issues/environmental-sustainability.md
+++ b/source/issues/environmental-sustainability.md
@@ -1,12 +1,10 @@
 ---
 excerpt: I will work aggressively to ensure a healthy and sustainable environment for future generations to come. I believe Roseville can be carbon neutral by 2050. Within the City Campus we already use Geothermal and Solar technologies. We can work toward a carbon neutral future by expanding these technologies throughout the City and working with the community on equitable green policies. Many cities in the United States are working toward aggressive carbon reduction standards and I will work to gather community input to adapt the current available frameworks to fit Roseville’s needs.
-layout: layout
+layout: issue
 order: 1
 section: Issues
 title: Environmental Sustainability
 ---
-
-## {{ page.title }}
 
 I will work aggressively to ensure a healthy and sustainable environment for future generations to come. I believe Roseville can be carbon neutral by 2050. Within the City Campus we already use Geothermal and Solar technologies. We can work toward a carbon neutral future by expanding these technologies throughout the City and working with the community on equitable green policies. Many cities in the United States are working toward aggressive carbon reduction standards and I will work to gather community input to adapt the current available frameworks to fit Roseville’s needs.
 

--- a/source/issues/urban-policy.md
+++ b/source/issues/urban-policy.md
@@ -1,12 +1,10 @@
 ---
 excerpt: "My Urban Policy will have four areas of focus: Affordable Housing, Small Business, Urban Development, and Sustainability. By designing policy focused on these areas of growth, residents can ensure the City maintains the balance between suburban and urban living and doing so in an ecologically balanced manner rooted in social justice and equity."
-layout: layout
+layout: issue
 order: 2
 section: Issues
 title: Urban Policy
 ---
-
-## {{ page.title }}
 
 My Urban Policy will have four areas of focus: Affordable Housing, Small Business, Urban Development, and Sustainability. By designing policy focused on these areas of growth, residents can ensure the City maintains the balance between suburban and urban living and doing so in an ecologically balanced manner rooted in social justice and equity.
 


### PR DESCRIPTION
Because:

* I hadn't updated from the Middleman syntax of `page.attr` to the Eleventy syntax of just `attr`, so the headings were missing

Solution:

* Use `{{ title }}` to render the title
* Pull that duplication out into an `issue`-specific layout
